### PR TITLE
TASK: Tweak TrustedProxy header evaluation

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Http/Component/TrustedProxiesComponent.php
@@ -52,11 +52,11 @@ class TrustedProxiesComponent implements ComponentInterface
         $hostHeader = $this->getFirstTrustedProxyHeaderValue(self::HEADER_HOST, $trustedRequest);
         $portFromHost = null;
         if ($hostHeader !== null) {
-            $portSeparator = strrpos($hostHeader, ':');
-            if ($portSeparator > 0) {
-                $portFromHost = substr($hostHeader, $portSeparator + 1);
+            $portSeparatorIndex = strrpos($hostHeader, ':');
+            if ($portSeparatorIndex !== false) {
+                $portFromHost = substr($hostHeader, $portSeparatorIndex + 1);
                 $trustedRequest->getUri()->setPort($portFromHost);
-                $hostHeader = substr($hostHeader, 0, $portSeparator);
+                $hostHeader = substr($hostHeader, 0, $portSeparatorIndex);
             }
             $trustedRequest->getUri()->setHost($hostHeader);
         }

--- a/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
+++ b/TYPO3.Flow/Tests/Unit/Http/Component/TrustedProxiesComponentTest.php
@@ -361,6 +361,16 @@ class TrustedProxiesComponentTest extends UnitTestCase
     /**
      * @test
      */
+    public function portIsOverridenIfTheHostHeaderContainsJustThePort()
+    {
+        $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_HOST' => ':443'));
+        $trustedRequest = $this->callWithRequest($request);
+        $this->assertEquals(443, $trustedRequest->getUri()->getPort());
+    }
+
+    /**
+     * @test
+     */
     public function portIsOverridenIfTheHostHeaderContainsPortAlsoIfProtocolHeaderIsSet()
     {
         $request = Request::create(new Uri('http://acme.com'), 'GET', array(), array(), array('HTTP_X_FORWARDED_HOST' => 'neos.io:443', 'HTTP_X_FORWARDED_PROTO' => 'http'));


### PR DESCRIPTION
Allow the `X-Forwarded-Host` to only specify the port to forward